### PR TITLE
[MRG] Update bad_recon to force MaxFilter with 30 bad channels

### DIFF
--- a/SSS/README.txt
+++ b/SSS/README.txt
@@ -36,4 +36,4 @@ MaxFilter params: '-regularize off -cal off -ctc off -iterate 0 -hpisubt off -au
 test_move_anon_raw_bad_recon_sss.fif
 Filter is using simplified params and 30 random bad channels.
 Data was cropped post hoc (after running MaxFilter) to keep only first second of data because '-skip' param wasn't working.
-MaxFilter params: '-regularize off -cal off -ctc off -iterate 0 -hpisubt off -autobad off -bad 0912 1722 2213 0132 1312 0432 2433 1022 0442 2332 0633 1043 1713 0422 0932 1622 1343 0943 0643 0143 2142 0813 2143 1323 0522 1123 0423 2122 2532 0812'
+MaxFilter params: '-regularize off -cal off -ctc off -iterate 0 -hpisubt off -autobad off -force -bad 0912 1722 2213 0132 1312 0432 2433 1022 0442 2332 0633 1043 1713 0422 0932 1622 1343 0943 0643 0143 2142 0813 2143 1323 0522 1123 0423 2122 2532 0812'


### PR DESCRIPTION
Fixes MaxFilter bailing out of filtering data by adding `-force` flag. MaxFilter will (by default) stop filtering if there are more than 12 channels.